### PR TITLE
feat: support GET method for webhooks

### DIFF
--- a/XianyuAutoAsync.py
+++ b/XianyuAutoAsync.py
@@ -2249,6 +2249,12 @@ class XianyuLive:
                             logger.info(f"Webhook通知发送成功")
                         else:
                             logger.warning(f"Webhook通知发送失败: {response.status}")
+                elif http_method == 'GET':
+                    async with session.get(webhook_url, params=data, headers=headers, timeout=10) as response:
+                        if response.status == 200:
+                            logger.info(f"Webhook通知发送成功")
+                        else:
+                            logger.warning(f"Webhook通知发送失败: {response.status}")
                 else:
                     logger.warning(f"不支持的HTTP方法: {http_method}")
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2726,7 +2726,7 @@ const channelTypeConfigs = {
     },
     webhook: {
     title: 'Webhook通知',
-    description: '通过HTTP POST请求发送通知到自定义的Webhook地址',
+    description: '通过HTTP请求发送通知到自定义的Webhook地址',
     icon: 'bi-link-45deg',
     color: 'warning',
     fields: [
@@ -2744,7 +2744,8 @@ const channelTypeConfigs = {
         type: 'select',
         options: [
             { value: 'POST', text: 'POST' },
-            { value: 'PUT', text: 'PUT' }
+            { value: 'PUT', text: 'PUT' },
+            { value: 'GET', text: 'GET' }
         ],
         required: true,
         help: '发送请求使用的HTTP方法'


### PR DESCRIPTION
## Summary
- support GET HTTP method for webhook notifications
- allow selecting GET in webhook configuration UI

## Testing
- `python -m py_compile XianyuAutoAsync.py`
- `node --check static/js/app.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68adbc2078a08329be4f331c8c6d090e